### PR TITLE
fix: PDF出力画面のKVフィールド設定が横にはみ出す問題を修正

### DIFF
--- a/frontend/src/features/lives/pdf/canvas/PropertyPanel.tsx
+++ b/frontend/src/features/lives/pdf/canvas/PropertyPanel.tsx
@@ -483,7 +483,7 @@ function FieldsRowEditor({
   return (
     <div className="space-y-1">
       {fields.map((row, i) => (
-        <div key={`${row.fieldId}-${i}`} className="flex items-center gap-1">
+        <div key={`${row.fieldId}-${i}`} className="flex min-w-0 items-center gap-1">
           <Select
             value={row.fieldId}
             onValueChange={(v) => {
@@ -494,7 +494,7 @@ function FieldsRowEditor({
               onUpdate({ source: { kind: 'fields', fields: next } });
             }}
           >
-            <SelectTrigger className="h-7 text-xs">
+            <SelectTrigger className="h-7 min-w-0 flex-1 text-xs">
               <SelectValue placeholder="フィールドを選択" />
             </SelectTrigger>
             <SelectContent>


### PR DESCRIPTION
FieldsRowEditor の SelectTrigger に幅指定がなく shadcn/ui の デフォルト w-fit のままだったため、フィールド名が長いとパネル幅を
超えて見切れていた。行コンテナに min-w-0、SelectTrigger に
min-w-0 flex-1 を付けて親幅に収まるようにした。